### PR TITLE
Implement head collection

### DIFF
--- a/src/main/java/de/pancake/daybreak/DaybreakPlugin.java
+++ b/src/main/java/de/pancake/daybreak/DaybreakPlugin.java
@@ -1,6 +1,7 @@
 package de.pancake.daybreak;
 
 import de.pancake.daybreak.commands.DaybreakCommand;
+import de.pancake.daybreak.commands.HeadsCommand;
 import de.pancake.daybreak.generators.VanillaGenerator;
 import de.pancake.daybreak.listeners.CombatListener;
 import de.pancake.daybreak.listeners.MiscListener;
@@ -61,8 +62,11 @@ public class DaybreakPlugin extends JavaPlugin implements Listener {
      */
     @Override @SneakyThrows
     public void onEnable() {
-        // register commands and listeners
+        // register commands
         Bukkit.getCommandMap().register("daybreak", "db", new DaybreakCommand(this));
+        Bukkit.getCommandMap().register("headcollection", "heads", new HeadsCommand());
+
+        // register listeners
         Bukkit.getPluginManager().registerEvents(new SurvivalListener(this), this);
         Bukkit.getPluginManager().registerEvents(new MiscListener(this), this);
         Bukkit.getPluginManager().registerEvents(new CombatListener(this), this);

--- a/src/main/java/de/pancake/daybreak/DaybreakPlugin.java
+++ b/src/main/java/de/pancake/daybreak/DaybreakPlugin.java
@@ -43,7 +43,9 @@ public class DaybreakPlugin extends JavaPlugin implements Listener {
     /** Size of the border */
     public static final int BORDER_RADIUS = 512;
     /** Data type of the head collection */
-    public static final HeadCollectionDataType HEAD_COLLECTION_DATA_TYPE = new HeadCollectionDataType();
+    public static final HeadCollectionDataType HEADS_TYPE = new HeadCollectionDataType();
+    /** Head collection key */
+    public static final NamespacedKey HEADS_KEY = new NamespacedKey("daybreak", "heads");
 
     /** List of survivors */
     private final List<UUID> survivors = new LinkedList<>();
@@ -51,8 +53,6 @@ public class DaybreakPlugin extends JavaPlugin implements Listener {
     public final List<UUID> lastSession = new LinkedList<>();
     /** Webhook executor */
     public final WebhookExecutor webhookExecutor = new WebhookExecutor();
-    /** Head collection key */
-    private final NamespacedKey headsKey = new NamespacedKey(this, "heads");
     /** Whether the server is online */
     @Getter private boolean online = false;
 
@@ -154,9 +154,9 @@ public class DaybreakPlugin extends JavaPlugin implements Listener {
             var pdc = killer.getPersistentDataContainer();
 
             // update head collection data
-            var data = (Map<UUID, Integer>) pdc.getOrDefault(headsKey, HEAD_COLLECTION_DATA_TYPE, new HashMap<UUID, Integer>());
+            var data = (Map<UUID, Integer>) pdc.getOrDefault(HEADS_KEY, HEADS_TYPE, new HashMap<UUID, Integer>());
             data.put(p.getUniqueId(), data.getOrDefault(p.getUniqueId(), 0) + 1);
-            pdc.set(headsKey, HEAD_COLLECTION_DATA_TYPE, data);
+            pdc.set(HEADS_KEY, HEADS_TYPE, data);
 
             // send message to killer
             var total = data.entrySet().stream().mapToInt(Map.Entry::getValue).sum();

--- a/src/main/java/de/pancake/daybreak/DaybreakPlugin.java
+++ b/src/main/java/de/pancake/daybreak/DaybreakPlugin.java
@@ -5,11 +5,13 @@ import de.pancake.daybreak.generators.VanillaGenerator;
 import de.pancake.daybreak.listeners.CombatListener;
 import de.pancake.daybreak.listeners.MiscListener;
 import de.pancake.daybreak.listeners.SurvivalListener;
+import de.pancake.daybreak.pdc.HeadCollectionDataType;
 import de.pancake.daybreak.webhook.WebhookExecutor;
 import lombok.Getter;
 import lombok.SneakyThrows;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -23,9 +25,7 @@ import java.nio.file.Files;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -42,6 +42,8 @@ public class DaybreakPlugin extends JavaPlugin implements Listener {
 
     /** Size of the border */
     public static final int BORDER_RADIUS = 512;
+    /** Data type of the head collection */
+    public static final HeadCollectionDataType HEAD_COLLECTION_DATA_TYPE = new HeadCollectionDataType();
 
     /** List of survivors */
     private final List<UUID> survivors = new LinkedList<>();
@@ -49,6 +51,8 @@ public class DaybreakPlugin extends JavaPlugin implements Listener {
     public final List<UUID> lastSession = new LinkedList<>();
     /** Webhook executor */
     public final WebhookExecutor webhookExecutor = new WebhookExecutor();
+    /** Head collection key */
+    private final NamespacedKey headsKey = new NamespacedKey(this, "heads");
     /** Whether the server is online */
     @Getter private boolean online = false;
 
@@ -143,6 +147,21 @@ public class DaybreakPlugin extends JavaPlugin implements Listener {
     public void kill(Player p) {
         if (p.isOp())
             return;
+
+        // add head to killer
+        var killer = p.getKiller();
+        if (killer != null) {
+            var pdc = killer.getPersistentDataContainer();
+
+            // update head collection data
+            var data = (Map<UUID, Integer>) pdc.getOrDefault(headsKey, HEAD_COLLECTION_DATA_TYPE, new HashMap<UUID, Integer>());
+            data.put(p.getUniqueId(), data.getOrDefault(p.getUniqueId(), 0) + 1);
+            pdc.set(headsKey, HEAD_COLLECTION_DATA_TYPE, data);
+
+            // send message to killer
+            var total = data.entrySet().stream().mapToInt(Map.Entry::getValue).sum();
+            killer.sendMessage(miniMessage().deserialize("<prefix>You have collected the head of <gold>" + p.getName() + "</gold>. You now have <gold>" + total + "</gold> head" + (total == 1 ? "" : "s") + ".", PREFIX));
+        }
 
         this.removeSurvivor(p.getUniqueId());
         p.setGameMode(GameMode.SPECTATOR);

--- a/src/main/java/de/pancake/daybreak/commands/HeadsCommand.java
+++ b/src/main/java/de/pancake/daybreak/commands/HeadsCommand.java
@@ -1,0 +1,73 @@
+package de.pancake.daybreak.commands;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static de.pancake.daybreak.DaybreakPlugin.HEADS_KEY;
+import static de.pancake.daybreak.DaybreakPlugin.HEADS_TYPE;
+import static de.pancake.daybreak.listeners.SurvivalListener.PREFIX;
+import static net.kyori.adventure.text.minimessage.MiniMessage.miniMessage;
+
+/**
+ * Daybreak's main command.
+ * @author Pancake
+ */
+public class HeadsCommand extends Command {
+
+    /**
+     * Initialize heads command.
+     */
+    public HeadsCommand() {
+        super("headcollection", "Command that shows the head collection of a player", "/headcollection", List.of("heads"));
+    }
+
+    /**
+     * Execute heads command.
+     * @param sender Source object which is executing this command
+     * @param commandLabel The alias of the command used
+     * @param args All arguments passed to the command, split via ' '
+     * @return Command success
+     */
+    @Override
+    public boolean execute(@NotNull CommandSender sender, @NotNull String commandLabel, @NotNull String[] args) {
+        if (sender instanceof Player p) {
+            // grab player head collection
+            var heads = (Map<UUID, Integer>) p.getPersistentDataContainer().getOrDefault(HEADS_KEY, HEADS_TYPE, new HashMap<UUID, Integer>());
+            var total = heads.entrySet().stream().mapToInt(Map.Entry::getValue).sum();
+
+            if (total == 0) {
+                sender.sendMessage(miniMessage().deserialize("<prefix><red>You don't have any heads yet!", PREFIX));
+                return true;
+            }
+
+            // create inventory
+            var inv = Bukkit.createInventory(null, (int) Math.ceil(heads.size() / 9.0)*9, Component.text("Your head collection (" + total + " heads)"));
+            for (var entry : heads.entrySet()) {
+                var skull = new ItemStack(Material.PLAYER_HEAD, entry.getValue());
+                var meta = (SkullMeta) skull.getItemMeta();
+                meta.setOwningPlayer(Bukkit.getOfflinePlayer(entry.getKey()));
+                meta.displayName(miniMessage().deserialize("<gold><!italic>" + Bukkit.getOfflinePlayer(entry.getKey()).getName(), PREFIX));
+                skull.setItemMeta(meta);
+                inv.addItem(skull);
+            }
+
+            // open inventory
+            p.openInventory(inv);
+        }
+
+        return true;
+    }
+
+}

--- a/src/main/java/de/pancake/daybreak/listeners/MiscListener.java
+++ b/src/main/java/de/pancake/daybreak/listeners/MiscListener.java
@@ -6,6 +6,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -83,7 +84,7 @@ public class MiscListener implements Listener {
      * Handle player death event.
      * @param e Player death event.
      */
-    @EventHandler
+    @EventHandler(priority = EventPriority.HIGH) // run after other event handlers
     public void onPlayerDeath(PlayerDeathEvent e) {
         var p = e.getPlayer();
         var killer = p.getKiller();

--- a/src/main/java/de/pancake/daybreak/listeners/MiscListener.java
+++ b/src/main/java/de/pancake/daybreak/listeners/MiscListener.java
@@ -5,11 +5,13 @@ import io.papermc.paper.event.player.AsyncChatEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
+import org.bukkit.Material;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.server.PluginEnableEvent;
@@ -78,6 +80,17 @@ public class MiscListener implements Listener {
     public void onPluginLoad(PluginEnableEvent e) {
         if (e.getPlugin().getName().equals("Chunky"))
             this.plugin.onChunkyInit(Bukkit.getWorld("world"));
+    }
+
+    /**
+     * Handle inventory click event.
+     * @param e Inventory click event.
+     */
+    @EventHandler
+    public void onInventoryClick(InventoryClickEvent e) {
+        var item = e.getInventory().getItem(0);
+        if (!e.getWhoClicked().isOp() && item != null && item.getType() == Material.PLAYER_HEAD)
+            e.setCancelled(true);
     }
 
     /**

--- a/src/main/java/de/pancake/daybreak/pdc/HeadCollectionDataType.java
+++ b/src/main/java/de/pancake/daybreak/pdc/HeadCollectionDataType.java
@@ -1,0 +1,55 @@
+package de.pancake.daybreak.pdc;
+
+import org.bukkit.persistence.PersistentDataAdapterContext;
+import org.bukkit.persistence.PersistentDataType;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+/**
+ * Persistent data type for head collections.
+ * @author Pancake
+ */
+public class HeadCollectionDataType implements PersistentDataType<String, Map> {
+
+    /**
+     * Convert a complex value to a primitive value.
+     * @param complex the complex object instance
+     * @param context the context this operation is running in
+     * @return
+     */
+    @Override
+    public @NotNull String toPrimitive(@NotNull Map complex, @NotNull PersistentDataAdapterContext context) {
+        return ((Map<UUID, Integer>) complex).entrySet().stream().map(entry -> entry.getKey() + ":" + entry.getValue()).collect(Collectors.joining(","));
+    }
+
+    /**
+     * Convert a primitive value to a complex value.
+     * @param primitive the primitive value
+     * @param context the context this operation is running in
+     * @return
+     */
+    @Override
+    public @NotNull Map fromPrimitive(@NotNull String primitive, @NotNull PersistentDataAdapterContext context) {
+        var map = new HashMap<UUID, Integer>();
+        for (var entry : primitive.split(",")) {
+            var split = entry.split(":");
+            map.put(UUID.fromString(split[0]), Integer.parseInt(split[1]));
+        }
+        return map;
+    }
+
+    @Override
+    public @NotNull Class<String> getPrimitiveType() {
+        return String.class;
+    }
+
+    @Override
+    public @NotNull Class<Map> getComplexType() {
+        return Map.class;
+    }
+
+}


### PR DESCRIPTION
Players can now view their head collection via /heads.
A player will obtain a head by killing another player and a player will lose all of their heads on death.