### PR TITLE
Fix discord webhooks not loading properly and players being marked as survivors incorrectly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,21 +24,21 @@ repositories {
     mavenCentral()
     // Add papermc repository for api
     maven { url "https://papermc.io/repo/repository/maven-public/" }
-    // Add codemc repository for api
+    // Add codemc repository for chunky
     maven { url "https://repo.codemc.io/repository/maven-public/" }
 }
 
 // Add paper api
 dependencies {
     // Add lombok processor
-    compileOnly 'org.projectlombok:lombok:1.18.30'
-    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    compileOnly 'org.projectlombok:lombok:1.18.32'
+    annotationProcessor 'org.projectlombok:lombok:1.18.32'
 
     // Add paper mc api for compile time
     compileOnly "io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT"
 
     // Add chunky api for compile time
-    compileOnly "org.popcraft:chunky-common:1.3.92"
+    compileOnly "org.popcraft:chunky-common:1.3.143"
 }
 
 // Upload plugin to server [login via key]

--- a/src/main/java/gay/pancake/daybreak/listeners/SurvivalListener.java
+++ b/src/main/java/gay/pancake/daybreak/listeners/SurvivalListener.java
@@ -87,7 +87,7 @@ public class SurvivalListener implements Listener {
         // add timer for adding player to survivors list
         var login = player.getLastLogin();
         Bukkit.getScheduler().runTaskLater(this.plugin, () -> {
-            if (player.getLastLogin() != login)
+            if (player.getLastLogin() != login || !player.isOnline())
                 return;
             this.plugin.addSurvivor(player.getUniqueId());
             player.sendMessage(miniMessage().deserialize("<prefix>You are now marked as a survivor", DaybreakPlugin.PREFIX));

--- a/src/main/java/gay/pancake/daybreak/webhook/WebhookExecutor.java
+++ b/src/main/java/gay/pancake/daybreak/webhook/WebhookExecutor.java
@@ -53,7 +53,7 @@ public class WebhookExecutor {
                     .replace("%HS%", total == 1 ? "" : "s")
                     .replace("%HEADS%", heads))
             .color(0x9F23EB)
-            .thumbnail(Image.builder().url("https://crafatar.com/avatars/" + p.getUniqueId() + "?overlay").build());
+            .thumbnail(Image.builder().url("https://mc-heads.net/avatar/" + p.getUniqueId() + "/160").build());
 
 
         // add killer footer
@@ -61,11 +61,11 @@ public class WebhookExecutor {
             if (c == null)
                 embed.footer(Footer.builder()
                     .text("Murdered by " + k.getName())
-                    .icon_url("https://crafatar.com/avatars/" + k.getUniqueId() + "?overlay").build());
+                    .icon_url("https://mc-heads.net/avatar/" + k.getUniqueId() + "/160").build());
             else
                 embed.footer(Footer.builder()
                     .text(k.getName() + " stole the " + c.getType().getName() + " and is now rank " + (c.getType().ordinal()+1) + ".")
-                    .icon_url("https://crafatar.com/avatars/" + k.getUniqueId() + "?overlay").build());
+                    .icon_url("https://mc-heads.net/avatar/" + k.getUniqueId() + "/160").build());
 
         // send webhook
         WebhookUtil.send(null, embed.build());

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,6 +1,6 @@
 name: Daybreak
 description: PortalRunner's Hardcore Server
-version: 1.1.1
+version: 1.1.2
 author: Pancake
 website: "https://mgnet.work"
 


### PR DESCRIPTION
Crafatar blocked discord servers so I can't use their API for fetching player heads anymore.

Secondly, the 5 minute timer is not stopped if the player is offline, so they still get marked as survivor if they die in the first 5 minutes.